### PR TITLE
Fix backend endpoint version check

### DIFF
--- a/src/main/java/net/elytrium/limboauth/backend/Endpoint.java
+++ b/src/main/java/net/elytrium/limboauth/backend/Endpoint.java
@@ -53,8 +53,9 @@ public abstract class Endpoint {
   }
 
   public void read(ByteArrayDataInput input) {
+    // Version written by #write is currently 1
     int version = input.readInt();
-    if (version != 0) {
+    if (version != 1) {
       throw new IllegalStateException("unsupported '" + this.type + "' endpoint version: " + version);
     }
 


### PR DESCRIPTION
### **User description**
## Summary
- correct the read() endpoint version check so it expects version 1

## Testing
- `./gradlew test --no-daemon`

------
https://chatgpt.com/codex/tasks/task_b_68513bf19b5c832995522424dfc0dd46


___

### **PR Type**
Bug fix


___

### **Description**
• Fix endpoint version check to expect version 1 instead of 0
• Add clarifying comment about current version number


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Endpoint.java</strong><dd><code>Fix endpoint version validation logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/main/java/net/elytrium/limboauth/backend/Endpoint.java

• Updated version check from 0 to 1 in read() method<br> • Added comment <br>explaining current version number


</details>


  </td>
  <td><a href="https://github.com/rafalohaki/LimboAuth/pull/2/files#diff-876d491965405d7de5b2567f91b1db00ef1f46476056424ecc277bcf7aaec6f4">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected version checking logic to ensure compatibility between data reading and writing processes.
  - Improved code comments for better clarity regarding version handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Update the backend endpoint version check to expect version 1 instead of version 0.

### Why are these changes being made?

The versioning convention was updated and the endpoint now writes a version number of 1; the version check was modified to align with this change to prevent exceptions related to version mismatch. This ensures compatibility with the current version format being used.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->