### PR TITLE
Fix typo in serializer warning

### DIFF
--- a/src/main/java/net/elytrium/limboauth/LimboAuth.java
+++ b/src/main/java/net/elytrium/limboauth/LimboAuth.java
@@ -257,7 +257,7 @@ public class LimboAuth {
 
     ComponentSerializer<Component, Component, String> serializer = Settings.IMP.SERIALIZER.getSerializer();
     if (serializer == null) {
-      LOGGER.warn("The specified serializer could not be founded, using default. (LEGACY_AMPERSAND)");
+      LOGGER.warn("The specified serializer could not be found, using default. (LEGACY_AMPERSAND)");
       setSerializer(new Serializer(Objects.requireNonNull(Serializers.LEGACY_AMPERSAND.getSerializer())));
     } else {
       setSerializer(new Serializer(serializer));


### PR DESCRIPTION
### **User description**
## Summary
- fix typo in `LimboAuth` serializer warning

## Testing
- `grep -n "could not be" -n src/main/java/net/elytrium/limboauth/LimboAuth.java`

------
https://chatgpt.com/codex/tasks/task_b_68513be9e7b08329b646b59cda93099b


___

### **PR Type**
Bug fix


___

### **Description**
• Fix typo in serializer warning message


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>LimboAuth.java</strong><dd><code>Fix typo in warning message</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/main/java/net/elytrium/limboauth/LimboAuth.java

• Corrected typo from "founded" to "found" in serializer warning <br>message


</details>


  </td>
  <td><a href="https://github.com/rafalohaki/LimboAuth/pull/4/files#diff-7374c4c11b73dbc2f432dbca73dd3a2d5d91f2d91653a21bf9412ee2768cc90b">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected a typo in a log warning message to improve clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Fix a typo in the logger warning message by changing "founded" to "found".

### Why are these changes being made?

The previous warning message contained a grammatical error, which could lead to misunderstandings. Correcting the typo ensures clear communication in the logs, accurately reflecting the intended message.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->