### PR TITLE
Fix protocol version in test

### DIFF
--- a/src/test/java/net/elytrium/limboauth/backend/EndpointTest.java
+++ b/src/test/java/net/elytrium/limboauth/backend/EndpointTest.java
@@ -18,7 +18,7 @@ public class EndpointTest {
 
     StringEndpoint source = new StringEndpoint(null, "premium_state", username, value);
     ByteArrayDataOutput out = ByteStreams.newDataOutput();
-    out.writeInt(0);
+    out.writeInt(1);
     out.writeUTF(username);
     source.writeContents(out);
 


### PR DESCRIPTION
### **User description**
## Summary
- update written version in `EndpointTest` to `1`

## Testing
- `./gradlew test`

------
https://chatgpt.com/codex/tasks/task_b_685142d5c1108329bb9ebe2e5889fd52


___

### **PR Type**
Bug fix


___

### **Description**
• Update protocol version from 0 to 1 in EndpointTest


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>EndpointTest.java</strong><dd><code>Update protocol version to 1</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/test/java/net/elytrium/limboauth/backend/EndpointTest.java

• Changed protocol version from 0 to 1 in stringEndpointSerialization <br>test method


</details>


  </td>
  <td><a href="https://github.com/rafalohaki/LimboAuth/pull/7/files#diff-c27b00bf7fe55f93ce276068f305d1c7dc7dbf4f806b389e57c5a7e1719b2350">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Update the test to write the correct protocol version by changing `out.writeInt(0)` to `out.writeInt(1)` in the `stringEndpointSerialization` method of `EndpointTest.java`.

### Why are these changes being made?

This change corrects the protocol version used in the test to align with the updated system requirements, ensuring that the test accurately reflects the expected behavior and output when interacting with the latest protocol. This was necessary due to changes in the protocol specification that were inadvertently not mirrored in the test configuration.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Updated the serialization test to use a different initial integer marker in the output stream.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->